### PR TITLE
Add NotEqualFilter missing arguments definition

### DIFF
--- a/Resources/config/filters.yml
+++ b/Resources/config/filters.yml
@@ -40,6 +40,8 @@ services:
 
   ivoz.api.filter.not_equal:
     class: Ivoz\Api\Doctrine\Orm\Filter\NotEqualFilter
+    arguments:
+      $properties: ~
     autowire: true
     autoconfigure: true
     tags: [ 'api_platform.filter' ]


### PR DESCRIPTION
This is required for PHP 8.2 compatibilty